### PR TITLE
ReasonablyTyped now works on TypeScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Name | Description | Status
 [reason](https://github.com/facebook/reason) | Ocaml skin | Alpha? Very usable, but still also very much in flux
 [qnd](https://github.com/kennetpostigo/qnd) | Quick and Dirty development builds for reason | Usable
 [grunt-bucklescript](https://github.com/askucher/grunt-bucklescript) | Grunt plugin | Unknown
-[ReasonablyTyped](https://github.com/rrdelaney/ReasonablyTyped) | Converts Flow and TypeScript library definitions to Bucklescript interfaces | Very basic
+[ReasonablyTyped](https://github.com/rrdelaney/ReasonablyTyped) | Converts Flow and TypeScript library definitions to Bucklescript interfaces | Basic
 [ts2re](https://github.com/joshaber/ts2re) | Convert TypeScript type declaration files to Reason externals | "super not ready for real use"
 
 ## Related Links

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 - [Tooling](#tooling)
 - [Related links](#related-links)
 - [Contribute](#contribute)
-  
+
 ## Bindings
 
 ### Frontend (browser)
@@ -31,7 +31,7 @@ Name | Description | Status
 [bucklescript-jquery](https://github.com/nebuta/bucklescript-jquery) | [jQuery](https://jquery.com/) - Swiss army knife | Unknown, Out of date build process
 [bs-dom](https://github.com/0zat/bs-dom) | [DOM API](https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model) | Very incomplete, "not test yet"
 [bucklescript-phx](https://github.com/phoenix-china/bucklescript-phx) | [Phoenix](http://www.phoenixframework.org/) client API | "work in progress"
-[bs-rebass](https://github.com/MasterOfPoppets/bs-rebass) | [Rebass](https://rebass-beta.now.sh/) - Stateless Component Library | Usable, Not complete 
+[bs-rebass](https://github.com/MasterOfPoppets/bs-rebass) | [Rebass](https://rebass-beta.now.sh/) - Stateless Component Library | Usable, Not complete
 [bs-glamor](https://github.com/poeschko/bs-glamor) | [glamor](https://github.com/threepointone/glamor) | Incomplete, but fully functional
 
 ### Backend (node)
@@ -111,7 +111,7 @@ Name | Description | Status
 [reason](https://github.com/facebook/reason) | Ocaml skin | Alpha? Very usable, but still also very much in flux
 [qnd](https://github.com/kennetpostigo/qnd) | Quick and Dirty development builds for reason | Usable
 [grunt-bucklescript](https://github.com/askucher/grunt-bucklescript) | Grunt plugin | Unknown
-[ReasonablyTyped](https://github.com/rrdelaney/ReasonablyTyped) | Converts Flow library definitions to Bucklescript interfaces | Very basic
+[ReasonablyTyped](https://github.com/rrdelaney/ReasonablyTyped) | Converts Flow and TypeScript library definitions to Bucklescript interfaces | Very basic
 [ts2re](https://github.com/joshaber/ts2re) | Convert TypeScript type declaration files to Reason externals | "super not ready for real use"
 
 ## Related Links


### PR DESCRIPTION
We added TS support to ReasonablyTyped in [v0.9](https://github.com/rrdelaney/ReasonablyTyped/releases/tag/v0.9.0) 🙂 

The other changes are just trimming line endings